### PR TITLE
Change CSV append mode to write mode and add comment for dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,4 +13,5 @@ torch==2.5.1
 transformers==4.45.0
 sentencepiece
 pandas
+# Required for TabM model (tabm_reference.py)
 rtdl_num_embeddings

--- a/src/TabM.py
+++ b/src/TabM.py
@@ -52,7 +52,7 @@ def main():
     os.makedirs(output_dir, exist_ok=True)
     output_path = os.path.join(output_dir, f'{args.model_name}.csv')
 
-    with open(output_path, 'a+', encoding='utf-8', newline='') as csvf:
+    with open(output_path, 'w', encoding='utf-8', newline='') as csvf:
         wr = csv.writer(csvf)
             
         train_path = os.path.join(args.output_dir, "REF", "labeling", f"{args.model_name}_labeled.json")


### PR DESCRIPTION
Fixes #1 와 Fixes #2 입니다. TabM.py의 csv 파일 쓰기 모드를 변경하고 의존성에 주석을 추가했어요. 이제 CSV 파일이 중복 없이 깔끔하게 저장되고 의존성 용도도 명확해집니다.